### PR TITLE
Reimplement `Sequence` storage without bitmaps

### DIFF
--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -155,7 +155,7 @@ cpdef void train_starts_nonsd(Nodes nodes, Sequence sequence, TrainingInfo tinf)
 
 cpdef void reset_node_scores(Nodes nodes) nogil
 cpdef void record_overlapping_starts(Nodes nodes, TrainingInfo tinf, bint is_meta=*) nogil
-cpdef int  dynamic_programming(Nodes nodes, TrainingInfo tinf, bint is_meta=*) nogil
+cpdef int  dynamic_programming(Nodes nodes, TrainingInfo tinf, bint final=*) nogil
 cpdef void eliminate_bad_genes(Nodes nodes, int ipath, TrainingInfo tinf) nogil
 cpdef void tweak_final_starts(Genes genes, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void record_gene_data(Genes genes, Nodes nodes, TrainingInfo tinf, int sequence_index) nogil

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -144,6 +144,7 @@ cpdef int add_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*)
 cpdef int add_genes(Genes genes, Nodes nodes, int ipath) nogil except -1
 cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except -1
 cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf, int stage) nogil except -1
+cpdef void raw_coding_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil
 cpdef void rbs_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil
 cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*, bint is_meta=*) nogil
 cpdef void score_upstream_composition(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf) nogil
@@ -159,7 +160,6 @@ cpdef void eliminate_bad_genes(Nodes nodes, int ipath, TrainingInfo tinf) nogil
 cpdef void tweak_final_starts(Genes genes, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void record_gene_data(Genes genes, Nodes nodes, TrainingInfo tinf, int sequence_index) nogil
 cpdef void calc_dicodon_gene(TrainingInfo tinf, Sequence sequence, Nodes nodes, int ipath) nogil
-cpdef void raw_coding_score(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void train_starts_sd(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void determine_sd_usage(TrainingInfo tinf) nogil
 cpdef void train_starts_nonsd(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -39,6 +39,7 @@ cdef class Sequence:
     cdef bint _is_gtg(self, int i, int strand=*) nogil
     cdef bint _is_ttg(self, int i, int strand=*) nogil
 
+    cdef int _mer_ndx(self, int i, int length, int strand=*) nogil
 
 
 # --- Nodes ------------------------------------------------------------------
@@ -139,6 +140,7 @@ cdef class Pyrodigal:
 cpdef int add_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*) nogil except -1
 cpdef int add_genes(Genes genes, Nodes nodes, int ipath) nogil except -1
 cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except -1
+cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf, int stage) nogil except -1
 cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*, bint is_meta=*) nogil
 
 # --- Wrappers ---------------------------------------------------------------

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -25,9 +25,6 @@ cdef public set    TRANSLATION_TABLES
 cdef class Sequence:
     cdef          int      slen
     cdef          uint8_t* digits
-    cdef          bitmap_t seq
-    cdef          bitmap_t rseq
-    cdef          bitmap_t useq
     cdef readonly double   gc
 
     cdef int _allocate(self, int slen) except 1
@@ -142,6 +139,8 @@ cdef class Pyrodigal:
 
 cpdef int add_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*) nogil except -1
 cpdef int add_genes(Genes genes, Nodes nodes, int ipath) nogil except -1
+cpdef void calc_dicodon_gene(TrainingInfo tinf, Sequence sequence, Nodes nodes, int ipath) nogil
+cdef int* calc_most_gc_frame(Sequence seq) nogil except NULL
 cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except -1
 cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf, int stage) nogil except -1
 cpdef void raw_coding_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -32,6 +32,7 @@ cdef class Sequence:
 
     cdef int _allocate(self, int slen) except 1
 
+    cdef bint _is_gc(self, int i, int strand=*) nogil
     cdef bint _is_stop(self, int i, int tt, int strand=*) nogil
     cdef bint _is_start(self, int i, int tt, int strand=*) nogil
     cdef bint _is_atg(self, int i, int strand=*) nogil
@@ -133,14 +134,17 @@ cdef class Pyrodigal:
     cpdef Predictions  find_genes(self, object sequence)
     cpdef TrainingInfo train(self, object sequence, bint force_nonsd=*, double st_wt=*, int translation_table=*)
 
-# --- C-level API ------------------------------------------------------------
+# --- C-level API reimplementation -------------------------------------------
 
 cpdef int add_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*) nogil except -1
 cpdef int add_genes(Genes genes, Nodes nodes, int ipath) nogil except -1
+cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except -1
+cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*, bint is_meta=*) nogil
+
+# --- Wrappers ---------------------------------------------------------------
 
 cpdef void reset_node_scores(Nodes nodes) nogil
 cpdef void record_overlapping_starts(Nodes nodes, TrainingInfo tinf, bint is_meta=*) nogil
-cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*, bint is_meta=*) nogil
 cpdef int  dynamic_programming(Nodes nodes, TrainingInfo tinf, bint is_meta=*) nogil
 cpdef void eliminate_bad_genes(Nodes nodes, int ipath, TrainingInfo tinf) nogil
 cpdef void tweak_final_starts(Genes genes, Nodes nodes, TrainingInfo tinf) nogil

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -3,6 +3,8 @@
 
 # ----------------------------------------------------------------------------
 
+from libc.stdint cimport uint8_t
+
 from pyrodigal.prodigal.bitmap cimport bitmap_t
 from pyrodigal.prodigal.gene cimport _gene
 from pyrodigal.prodigal.metagenomic cimport NUM_META, _metagenomic_bin
@@ -22,12 +24,21 @@ cdef public set    TRANSLATION_TABLES
 
 cdef class Sequence:
     cdef          int      slen
+    cdef          uint8_t* digits
     cdef          bitmap_t seq
     cdef          bitmap_t rseq
     cdef          bitmap_t useq
     cdef readonly double   gc
 
     cdef int _allocate(self, int slen) except 1
+
+    cdef bint _is_stop(self, int i, int tt, int strand=*) nogil
+    cdef bint _is_start(self, int i, int tt, int strand=*) nogil
+    cdef bint _is_atg(self, int i, int strand=*) nogil
+    cdef bint _is_gtg(self, int i, int strand=*) nogil
+    cdef bint _is_ttg(self, int i, int strand=*) nogil
+
+
 
 # --- Nodes ------------------------------------------------------------------
 

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -142,6 +142,7 @@ cpdef int add_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*)
 cpdef int add_genes(Genes genes, Nodes nodes, int ipath) nogil except -1
 cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except -1
 cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf, int stage) nogil except -1
+cpdef void rbs_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil
 cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*, bint is_meta=*) nogil
 cpdef void score_upstream_composition(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf) nogil
 
@@ -155,7 +156,6 @@ cpdef void tweak_final_starts(Genes genes, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void record_gene_data(Genes genes, Nodes nodes, TrainingInfo tinf, int sequence_index) nogil
 cpdef void calc_dicodon_gene(TrainingInfo tinf, Sequence sequence, Nodes nodes, int ipath) nogil
 cpdef void raw_coding_score(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil
-cpdef void rbs_score(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void train_starts_sd(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void determine_sd_usage(TrainingInfo tinf) nogil
 cpdef void train_starts_nonsd(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -32,6 +32,8 @@ cdef class Sequence:
 
     cdef int _allocate(self, int slen) except 1
 
+    cdef bint _is_a(self, int i, int strand=*) nogil
+    cdef bint _is_g(self, int i, int strand=*) nogil
     cdef bint _is_gc(self, int i, int strand=*) nogil
     cdef bint _is_stop(self, int i, int tt, int strand=*) nogil
     cdef bint _is_start(self, int i, int tt, int strand=*) nogil
@@ -145,6 +147,8 @@ cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingIn
 cpdef void rbs_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil
 cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*, bint is_meta=*) nogil
 cpdef void score_upstream_composition(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf) nogil
+cpdef int shine_dalgarno_exact(Sequence seq, int pos, int start, TrainingInfo tinf, int strand=*) nogil
+cpdef int shine_dalgarno_mm(Sequence seq, int pos, int start, TrainingInfo tinf, int strand=*) nogil
 
 # --- Wrappers ---------------------------------------------------------------
 

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -142,6 +142,7 @@ cpdef int add_genes(Genes genes, Nodes nodes, int ipath) nogil except -1
 cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except -1
 cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf, int stage) nogil except -1
 cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=*, bint is_meta=*) nogil
+cpdef void score_upstream_composition(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf) nogil
 
 # --- Wrappers ---------------------------------------------------------------
 

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -150,6 +150,7 @@ cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed
 cpdef void score_upstream_composition(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf) nogil
 cpdef int shine_dalgarno_exact(Sequence seq, int pos, int start, TrainingInfo tinf, int strand=*) nogil
 cpdef int shine_dalgarno_mm(Sequence seq, int pos, int start, TrainingInfo tinf, int strand=*) nogil
+cpdef void train_starts_nonsd(Nodes nodes, Sequence sequence, TrainingInfo tinf) nogil
 
 # --- Wrappers ---------------------------------------------------------------
 
@@ -160,9 +161,8 @@ cpdef void eliminate_bad_genes(Nodes nodes, int ipath, TrainingInfo tinf) nogil
 cpdef void tweak_final_starts(Genes genes, Nodes nodes, TrainingInfo tinf) nogil
 cpdef void record_gene_data(Genes genes, Nodes nodes, TrainingInfo tinf, int sequence_index) nogil
 cpdef void calc_dicodon_gene(TrainingInfo tinf, Sequence sequence, Nodes nodes, int ipath) nogil
-cpdef void train_starts_sd(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil
+cpdef void train_starts_sd(Nodes nodes, Sequence sequence, TrainingInfo tinf) nogil
 cpdef void determine_sd_usage(TrainingInfo tinf) nogil
-cpdef void train_starts_nonsd(Sequence sequence, Nodes nodes, TrainingInfo tinf) nogil
 
 # --- Main functions ---------------------------------------------------------
 

--- a/pyrodigal/_pyrodigal.pxd
+++ b/pyrodigal/_pyrodigal.pxd
@@ -40,6 +40,7 @@ cdef class Sequence:
     cdef bint _is_ttg(self, int i, int strand=*) nogil
 
     cdef int _mer_ndx(self, int i, int length, int strand=*) nogil
+    cdef char _amino(self, int i, int tt, int strand=*, bint is_init=*) nogil
 
 
 # --- Nodes ------------------------------------------------------------------

--- a/pyrodigal/_pyrodigal.pyx
+++ b/pyrodigal/_pyrodigal.pyx
@@ -1507,6 +1507,32 @@ cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except
                 nodes.nodes[i].gc_cont = gc[phase] / gsize
                 last[phase] = nodes.nodes[i].ndx
 
+cpdef void count_upstream_composition(Sequence seq, TrainingInfo tinf, int pos, int strand=1) nogil:
+
+    cdef int start
+    cdef int j
+    cdef int i     = 0
+
+    if strand == 1:
+        for j in range(1, 3):
+            if pos - j >= 0:
+                tinf.tinf.ups_comp[i][seq.digits[pos-j] & 0b11] += 1
+            i += 1
+        for j in range(15, 45):
+            if pos - j >= 0:
+                tinf.tinf.ups_comp[i][seq.digits[pos-j] & 0b11] += 1
+            i += 1
+    else:
+        start = seq.slen - 1 - pos
+        for j in range(1, 3):
+            if pos + j < seq.slen:
+                tinf.tinf.ups_comp[i][_translation[seq.digits[pos+j]] & 0b11] += 1
+            i += 1
+        for j in range(15, 45):
+            if pos + j < seq.slen:
+                tinf.tinf.ups_comp[i][_translation[seq.digits[pos+j]] & 0b11] += 1
+            i += 1
+
 cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingInfo tinf, int stage) nogil except -1:
     cdef int i
     cdef int j
@@ -2320,12 +2346,6 @@ cpdef void train_starts_sd(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil:
 
 
 # --- Wrappers ---------------------------------------------------------------
-
-cpdef inline void count_upstream_composition(Sequence seq, TrainingInfo tinf, int pos, int strand=1) nogil:
-    if strand == 1:
-        node.count_upstream_composition(seq.seq, seq.slen, strand, pos, tinf.tinf)
-    else:
-        node.count_upstream_composition(seq.rseq, seq.slen, strand, pos, tinf.tinf)
 
 cpdef inline void reset_node_scores(Nodes nodes) nogil:
     node.reset_node_scores(nodes.nodes, nodes.length)

--- a/pyrodigal/_pyrodigal.pyx
+++ b/pyrodigal/_pyrodigal.pyx
@@ -2016,36 +2016,36 @@ cpdef int shine_dalgarno_exact(Sequence seq, int pos, int start, TrainingInfo ti
     cdef int max_val
     cdef int cmp_val
     cdef int cur_val = 0
-    cdef double match[6]
-    cdef double cur_ctr
-    cdef double dis_flag
+    cdef int match[6]
+    cdef int cur_ctr
+    cdef int dis_flag
 
     limit = start - 4 - pos
     if limit > 6:
         limit = 6
     for i in range(limit, 6):
-        match[i] = -10.0
+        match[i] = -10
 
     # Compare the 6-base region to AGGAGG
     for i in range(limit):
         if pos + i < 0:
             continue
         if i%3 == 0 and seq._is_a(pos+i, strand=strand):
-            match[i] = 2.0
+            match[i] = 2
         elif i%3 != 0 and seq._is_g(pos+i, strand=strand):
-            match[i] = 3.0
+            match[i] = 3
         else:
-            match[i] = -10.0
+            match[i] = -10
 
     # Find the maximally scoring motif
     max_val = 0
     for i in range(limit, 2, -1):
         for j in range(limit+1-i):
-            cur_ctr = -2.0;
+            cur_ctr = -2
             mism = 0;
             for k in range(j, j+i):
                 cur_ctr += match[k]
-                if match[k] < 0.0:
+                if match[k] < 0:
                     mism += 1
             if mism > 0:
                 continue
@@ -2066,55 +2066,55 @@ cpdef int shine_dalgarno_exact(Sequence seq, int pos, int start, TrainingInfo ti
                 continue
 
             # Exact-Matching RBS Motifs
-            if cur_ctr < 6.0:
+            if cur_ctr < 6:
                 cur_val = 0
-            elif cur_ctr == 6.0 and dis_flag == 2:
+            elif cur_ctr == 6 and dis_flag == 2:
                 cur_val = 1
-            elif cur_ctr == 6.0 and dis_flag == 3:
+            elif cur_ctr == 6 and dis_flag == 3:
                 cur_val = 2
-            elif cur_ctr == 8.0 and dis_flag == 3:
+            elif cur_ctr == 8 and dis_flag == 3:
                 cur_val = 3
-            elif cur_ctr == 9.0 and dis_flag == 3:
+            elif cur_ctr == 9 and dis_flag == 3:
                 cur_val = 3
-            elif cur_ctr == 6.0 and dis_flag == 1:
+            elif cur_ctr == 6 and dis_flag == 1:
                 cur_val = 6
-            elif cur_ctr == 11.0 and dis_flag == 3:
+            elif cur_ctr == 11 and dis_flag == 3:
                 cur_val = 10
-            elif cur_ctr == 12.0 and dis_flag == 3:
+            elif cur_ctr == 12 and dis_flag == 3:
                 cur_val = 10
-            elif cur_ctr == 14.0 and dis_flag == 3:
+            elif cur_ctr == 14 and dis_flag == 3:
                 cur_val = 10
-            elif cur_ctr == 8.0 and dis_flag == 2:
+            elif cur_ctr == 8 and dis_flag == 2:
                 cur_val = 11
-            elif cur_ctr == 9.0 and dis_flag == 2:
+            elif cur_ctr == 9 and dis_flag == 2:
                 cur_val = 11
-            elif cur_ctr == 8.0 and dis_flag == 1:
+            elif cur_ctr == 8 and dis_flag == 1:
                 cur_val = 12
-            elif cur_ctr == 9.0 and dis_flag == 1:
+            elif cur_ctr == 9 and dis_flag == 1:
                 cur_val = 12
-            elif cur_ctr == 6.0 and dis_flag == 0:
+            elif cur_ctr == 6 and dis_flag == 0:
                 cur_val = 13
-            elif cur_ctr == 8.0 and dis_flag == 0:
+            elif cur_ctr == 8 and dis_flag == 0:
                 cur_val = 15
-            elif cur_ctr == 9.0 and dis_flag == 0:
+            elif cur_ctr == 9 and dis_flag == 0:
                 cur_val = 16
-            elif cur_ctr == 11.0 and dis_flag == 2:
+            elif cur_ctr == 11 and dis_flag == 2:
                 cur_val = 20
-            elif cur_ctr == 11.0 and dis_flag == 1:
+            elif cur_ctr == 11 and dis_flag == 1:
                 cur_val = 21
-            elif cur_ctr == 11.0 and dis_flag == 0:
+            elif cur_ctr == 11 and dis_flag == 0:
                 cur_val = 22
-            elif cur_ctr == 12.0 and dis_flag == 2:
+            elif cur_ctr == 12 and dis_flag == 2:
                 cur_val = 20
-            elif cur_ctr == 12.0 and dis_flag == 1:
+            elif cur_ctr == 12 and dis_flag == 1:
                 cur_val = 23
-            elif cur_ctr == 12.0 and dis_flag == 0:
+            elif cur_ctr == 12 and dis_flag == 0:
                 cur_val = 24
-            elif cur_ctr == 14.0 and dis_flag == 2:
+            elif cur_ctr == 14 and dis_flag == 2:
                 cur_val = 25
-            elif cur_ctr == 14.0 and dis_flag == 1:
+            elif cur_ctr == 14 and dis_flag == 1:
                 cur_val = 26
-            elif cur_ctr == 14.0 and dis_flag == 0:
+            elif cur_ctr == 14 and dis_flag == 0:
                 cur_val = 27
 
             if tinf.tinf.rbs_wt[cur_val] < tinf.tinf.rbs_wt[max_val]:
@@ -2135,37 +2135,37 @@ cpdef int shine_dalgarno_mm(Sequence seq, int pos, int start, TrainingInfo tinf,
     cdef int max_val
     cdef int cmp_val
     cdef int cur_val = 0
-    cdef double match[6]
-    cdef double cur_ctr
-    cdef double dis_flag
+    cdef int match[6]
+    cdef int cur_ctr
+    cdef int dis_flag
 
     limit = start - 4 - pos
     if limit > 6:
         limit = 6
     for i in range(limit, 6):
-        match[i] = -10.0
+        match[i] = -10
 
     # Compare the 6-base region to AGGAGG
     for i in range(limit):
         if pos + i < 0:
             continue
         if i%3 == 0:
-            match[i] = 2.0 if seq._is_a(pos+i, strand=strand) else -3.0
+            match[i] = 2 if seq._is_a(pos+i, strand=strand) else -3
         else:
-            match[i] = 3.0 if seq._is_g(pos+i, strand=strand) else -2.0
+            match[i] = 3 if seq._is_g(pos+i, strand=strand) else -2
 
     # Find the maximally scoring motif
     max_val = 0
     for i in range(limit, 4, -1):
         for j in range(limit+1-i):
-            cur_ctr = -2.0;
+            cur_ctr = -2
             mism = 0;
             for k in range(j, j+i):
                 cur_ctr += match[k]
                 if match[k] < 0.0:
                     mism += 1
                     if k <= j+1 or k >= j+i-2:
-                      cur_ctr -= 10.0
+                      cur_ctr -= 10
             if mism != 1:
                 continue
             rdis = start - (pos + j + i)
@@ -2177,35 +2177,35 @@ cpdef int shine_dalgarno_mm(Sequence seq, int pos, int start, TrainingInfo tinf,
                 dis_flag = 3
             else:
                 dis_flag = 0
-            if rdis > 15 or cur_ctr < 6.0:
+            if rdis > 15 or cur_ctr < 6:
                 continue
 
             # Single-Matching RBS Motifs
-            if cur_ctr < 6.0:
+            if cur_ctr < 6:
                 cur_val = 0
-            elif cur_ctr == 6.0 and dis_flag == 3:
+            elif cur_ctr == 6 and dis_flag == 3:
                 cur_val = 2
-            elif cur_ctr == 7.0 and dis_flag == 3:
+            elif cur_ctr == 7 and dis_flag == 3:
                 cur_val = 2
-            elif cur_ctr == 9.0 and dis_flag == 3:
+            elif cur_ctr == 9 and dis_flag == 3:
                 cur_val = 3
-            elif cur_ctr == 6.0 and dis_flag == 2:
+            elif cur_ctr == 6 and dis_flag == 2:
                 cur_val = 4
-            elif cur_ctr == 6.0 and dis_flag == 1:
+            elif cur_ctr == 6 and dis_flag == 1:
                 cur_val = 5
-            elif cur_ctr == 6.0 and dis_flag == 0:
+            elif cur_ctr == 6 and dis_flag == 0:
                 cur_val = 9
-            elif cur_ctr == 7.0 and dis_flag == 2:
+            elif cur_ctr == 7 and dis_flag == 2:
                 cur_val = 7
-            elif cur_ctr == 7.0 and dis_flag == 1:
+            elif cur_ctr == 7 and dis_flag == 1:
                 cur_val = 8
-            elif cur_ctr == 7.0 and dis_flag == 0:
+            elif cur_ctr == 7 and dis_flag == 0:
                 cur_val = 14
-            elif cur_ctr == 9.0 and dis_flag == 2:
+            elif cur_ctr == 9 and dis_flag == 2:
                 cur_val = 17
-            elif cur_ctr == 9.0 and dis_flag == 1:
+            elif cur_ctr == 9 and dis_flag == 1:
                 cur_val = 18
-            elif cur_ctr == 9.0 and dis_flag == 0:
+            elif cur_ctr == 9 and dis_flag == 0:
                 cur_val = 19
 
             if tinf.tinf.rbs_wt[cur_val] < tinf.tinf.rbs_wt[max_val]:

--- a/pyrodigal/_pyrodigal.pyx
+++ b/pyrodigal/_pyrodigal.pyx
@@ -1281,7 +1281,7 @@ cpdef int add_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=Fa
         if not closed:
             while last[(i+slmod)%3] + 3 > seq.slen:
                 last[(i+slmod)%3] -= 3
-    for i in range(seq.slen-3, -1, -1):
+    for i in reversed(range(seq.slen-2)):
         if seq._is_stop(i, tt):
             if saw_start[i%3]:
                 nodes._add_node(
@@ -1358,7 +1358,7 @@ cpdef int add_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed=Fa
         if not closed:
             while last[(i+slmod) % 3] + 3 > seq.slen:
                 last[(i+slmod)%3] -= 3
-    for i in range(seq.slen-3, -1, -1):
+    for i in reversed(range(seq.slen-2)):
         if seq._is_stop(i, tt, strand=-1):
             if saw_start[i%3]:
                 nodes._add_node(
@@ -1479,7 +1479,7 @@ cpdef int calc_orf_gc(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil except
 
     # direct strand
     gc[0] = gc[1] = gc[2] = 0.0
-    for i in range(nodes.length - 1, -1, -1):
+    for i in reversed(range(nodes.length)):
         phase = nodes.nodes[i].ndx %3
         if nodes.nodes[i].strand == 1:
             if nodes.nodes[i].type == node_type.STOP:
@@ -1529,7 +1529,7 @@ cpdef int find_best_upstream_motif(Nodes nodes, int ni, Sequence seq, TrainingIn
     else:
         start = seq.slen - 1 - nodes.nodes[ni].ndx
 
-    for i in range(3, -1, -1):
+    for i in reversed(range(3)):
         for j in range(start-18-i, start-5-i):
             if j < 0:
                 continue
@@ -1589,13 +1589,13 @@ cpdef void raw_coding_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil:
 
     # Initial Pass: Score coding potential (start->stop)
     score[0] = score[1] = score[2] = 0.0
-    for i in range(nn-1, -1, -1):
+    for i in reversed(range(nn)):
         phase = nodes.nodes[i].ndx%3
         if nodes.nodes[i].strand == 1 and nodes.nodes[i].type == node_type.STOP:
             last[phase] = nodes.nodes[i].ndx
             score[phase] = 0.0
         elif nodes.nodes[i].strand == 1:
-            for j in range(last[phase]-3, nodes.nodes[i].ndx - 1, -3):
+            for j in range(last[phase] - 3, nodes.nodes[i].ndx - 1, -3):
                 score[phase] += tinf.tinf.gene_dc[seq._mer_ndx(j, length=6, strand=1)];
             nodes.nodes[i].cscore = score[phase]
             last[phase] = nodes.nodes[i].ndx
@@ -1606,7 +1606,7 @@ cpdef void raw_coding_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil:
             last[phase] = nodes.nodes[i].ndx
             score[phase] = 0.0
         elif nodes.nodes[i].strand == -1:
-            for j in range(last[phase]+3, nodes.nodes[i].ndx+1, 3):
+            for j in range(last[phase] + 3, nodes.nodes[i].ndx + 1, 3):
                 score[phase] += tinf.tinf.gene_dc[seq._mer_ndx(seq.slen-1-j, length=6, strand=-1)]
             nodes.nodes[i].cscore = score[phase]
             last[phase] = nodes.nodes[i].ndx
@@ -1623,7 +1623,7 @@ cpdef void raw_coding_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil:
           else:
               nodes.nodes[i].cscore -= score[phase] - nodes.nodes[i].cscore
     score[0] = score[1] = score[2] = -10000.0
-    for i in range(nn-1, -1, -1):
+    for i in reversed(range(nn)):
         phase = nodes.nodes[i].ndx%3
         if nodes.nodes[i].strand == -1 and nodes.nodes[i].type == node_type.STOP:
             score[phase] = -10000.0
@@ -1655,7 +1655,7 @@ cpdef void raw_coding_score(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil:
             if lfac > 3.0 and nodes.nodes[i].cscore < 0.5*lfac:
                 nodes.nodes[i].cscore = 0.5*lfac;
             nodes.nodes[i].cscore += lfac;
-    for i in range(nn-1, -1, -1):
+    for i in reversed(range(nn)):
         phase = nodes.nodes[i].ndx%3;
         if nodes.nodes[i].strand == -1 and nodes.nodes[i].type == node_type.STOP:
             score[phase] = -10000.0;
@@ -1794,7 +1794,7 @@ cpdef void score_nodes(Nodes nodes, Sequence seq, TrainingInfo tinf, bint closed
             elif not closed and nodes.nodes[i].ndx >= seq.slen - 3 and nodes.nodes[i].strand == -1:
                 nodes.nodes[i].uscore += node.EDGE_UPS*tinf.tinf.st_wt
             elif i < 500 and nodes.nodes[i].strand == 1:
-                for j in range(i-1, -1, -1):
+                for j in reversed(range(i)):
                     if nodes.nodes[j].edge and nodes.nodes[i].stop_val == nodes.nodes[j].stop_val:
                         nodes.nodes[i].uscore += node.EDGE_UPS*tinf.tinf.st_wt
                         break
@@ -2217,7 +2217,7 @@ cpdef void train_starts_sd(Nodes nodes, Sequence seq, TrainingInfo tinf) nogil:
             bndx[j] = -1
             rbs[j] = 0
             type[j] = 0
-        for j in range(nn-1, -1, -1):
+        for j in reversed(range(nn)):
             if nodes.nodes[j].type != node_type.STOP and nodes.nodes[j].edge:
                 continue
             phase =  nodes.nodes[j].ndx % 3

--- a/pyrodigal/prodigal/dprog.pxd
+++ b/pyrodigal/prodigal/dprog.pxd
@@ -3,6 +3,11 @@ from pyrodigal.prodigal.training cimport _training
 
 
 cdef extern from "dprog.h" nogil:
+
+    const int MAX_SAM_OVLP  = 60
+    const int MAX_OPP_OVLP  = 200
+    const int MAX_NODE_DIST = 500
+
     int dprog(_node*, int, _training*, int)
     void score_connection(_node*, int, int, _training*, int)
     void eliminate_bad_genes(_node*, int, _training*)

--- a/pyrodigal/prodigal/node.pxd
+++ b/pyrodigal/prodigal/node.pxd
@@ -57,7 +57,9 @@ cdef extern from "node.h" nogil:
     void calc_amino_bg(_training*, unsigned char*, unsigned char*, int, _node*, int)
 
     void score_nodes(unsigned char*, unsigned char*, int, _node*, int, _training*, int, int)
-    void rbs_score(unsigned char*, unsigned char*, int, _node *, int, _training *);
+    void calc_orf_gc(unsigned char*, unsigned char*, int, _node*, int, _training*)
+    void rbs_score(unsigned char*, unsigned char*, int, _node *, int, _training*)
+    void score_upstream_composition(unsigned char*, int, _node*, _training*)
 
     void raw_coding_score(bitmap_t seq, bitmap_t rseq, int slen, _node *nod, int nn, _training *tinf)
 
@@ -66,4 +68,9 @@ cdef extern from "node.h" nogil:
     void train_starts_sd(bitmap_t seq, bitmap_t rseq, int slen, _node *nodes, int nn, _training *tinf)
     void train_starts_nonsd(bitmap_t seq, bitmap_t rseq, int slen, _node *nodes, int nn, _training *tinf)
 
+    void find_best_upstream_motif(_training*, unsigned char*, unsigned char*, int, _node*, int)
+
     bint cross_mask(int, int, _mask*, int)
+
+    double dmax(double, double)
+    double dmin(double, double)

--- a/pyrodigal/prodigal/node.pxd
+++ b/pyrodigal/prodigal/node.pxd
@@ -70,7 +70,9 @@ cdef extern from "node.h" nogil:
 
     void count_upstream_composition(unsigned char*, int, int, int, _training*)
 
+    void build_coverage_map(double[4][4][4096], int[4][4][4096], double, int)
     void find_best_upstream_motif(_training*, unsigned char*, unsigned char*, int, _node*, int)
+    void update_motif_counts(double[4][4][4096], double*, unsigned char*, unsigned char*, int, _node*, int)
 
     bint cross_mask(int, int, _mask*, int)
 

--- a/pyrodigal/prodigal/node.pxd
+++ b/pyrodigal/prodigal/node.pxd
@@ -68,6 +68,8 @@ cdef extern from "node.h" nogil:
     void train_starts_sd(bitmap_t seq, bitmap_t rseq, int slen, _node *nodes, int nn, _training *tinf)
     void train_starts_nonsd(bitmap_t seq, bitmap_t rseq, int slen, _node *nodes, int nn, _training *tinf)
 
+    void count_upstream_composition(unsigned char*, int, int, int, _training*)
+
     void find_best_upstream_motif(_training*, unsigned char*, unsigned char*, int, _node*, int)
 
     bint cross_mask(int, int, _mask*, int)

--- a/pyrodigal/prodigal/sequence.pxd
+++ b/pyrodigal/prodigal/sequence.pxd
@@ -45,3 +45,6 @@ cdef extern from "sequence.h" nogil:
     int mer_ndx(int, unsigned char*, int)
     void mer_text(char*, int, int)
     void calc_mer_bg(int, unsigned char*, unsigned char*, int, double*)
+
+    int shine_dalgarno_exact(unsigned char*, int, int, double*);
+    int shine_dalgarno_mm(unsigned char*, int, int, double*);

--- a/pyrodigal/prodigal/sequence.pxd
+++ b/pyrodigal/prodigal/sequence.pxd
@@ -41,3 +41,7 @@ cdef extern from "sequence.h" nogil:
     char amino_letter(int)
 
     int* calc_most_gc_frame(bitmap_t seq, int slen)
+
+    int mer_ndx(int, unsigned char*, int)
+    void mer_text(char*, int, int)
+    void calc_mer_bg(int, unsigned char*, unsigned char*, int, double*)

--- a/pyrodigal/prodigal/sequence.pxd
+++ b/pyrodigal/prodigal/sequence.pxd
@@ -40,6 +40,8 @@ cdef extern from "sequence.h" nogil:
     int amino_num(char)
     char amino_letter(int)
 
+    int max_fr(int, int, int)
+
     int* calc_most_gc_frame(bitmap_t seq, int slen)
 
     int mer_ndx(int, unsigned char*, int)


### PR DESCRIPTION
The original Prodigal implementation uses bitmaps to store the input sequences, which allows storing both strands in the usual indexing order, and reduces overall memory consumption by 35% (using a 2-bitmap for the forward strand, a 2-bitmap for the reverse strand, and a 1-bitmap to mark unknown characters). However this approach also comes with sensible drawbacks: testing a bitmap takes more time and prevents SIMD implementation.

This PR reimplements most of the functions in the Prodigal C code as Cython function that work with a sequence stored in a contiguous `uint8_t` array instead of bitmaps, among other things. 