### PR TITLE
Fix `--no-stop-codon` behaviour

### DIFF
--- a/src/pyrodigal/cli.py
+++ b/src/pyrodigal/cli.py
@@ -192,9 +192,9 @@ def argument_parser(
     parser.add_argument(
         "--no-stop-codon",
         required=False,
-        action="store_false",
+        action="store_true",
         help="Disables translation of stop codons into star characters (*) for complete genes.",
-        default=True,
+        default=False,
     )
     parser.add_argument(
         "--pool",
@@ -310,7 +310,7 @@ def main(
                     preds.write_genes(nuc_file, seq_id)
                 # if asked, write amino acid sequences of proteins
                 if prot_file is not None:
-                    preds.write_translations(prot_file, seq_id, include_stop=args.no_stop_codon)
+                    preds.write_translations(prot_file, seq_id, include_stop=not args.no_stop_codon)
                 # if asked, write scores
                 if scores_file is not None:
                     preds.write_scores(scores_file, seq_id)


### PR DESCRIPTION
The `--no-stop-codon` behaviour is confusing right now, as it is set to `True` by default but the stop codons are being written. This PR fixes that by changing the default value to `False` and inverting the boolean when it is passed to the `include_stop` parameter.